### PR TITLE
Add zip64 extensions to enable large file restores

### DIFF
--- a/burpui/utils.py
+++ b/burpui/utils.py
@@ -152,7 +152,7 @@ class BUIcompress():
     def __enter__(self):
         self.arch = None
         if self.archive == 'zip':
-            self.arch = zipfile.ZipFile(self.name, mode='w', compression=zipfile.ZIP_DEFLATED)
+            self.arch = zipfile.ZipFile(self.name, mode='w', compression=zipfile.ZIP_DEFLATED,allowZip64="True")
         elif self.archive == 'tar.gz':
             self.arch = tarfile.open(self.name, 'w:gz')
         elif self.archive == 'tar.bz2':


### PR DESCRIPTION
Allows burpui to zip and restore files > 2GB